### PR TITLE
[BUGFIX] Removed $GLOBALS['TSFE']->initFEuser(); from Jumpurl Hook

### DIFF
--- a/Classes/Hooks/JumpurlController.php
+++ b/Classes/Hooks/JumpurlController.php
@@ -125,7 +125,6 @@ class JumpurlController
                                     $_POST['pass'] = $recipRow['password'];
                                     $_POST['pid']  = $recipRow['pid'];
                                     $_POST['logintype'] = 'login';
-                                    $GLOBALS['TSFE']->initFEuser();
                                 }
                             } else {
                                 throw new \Exception('authCode: Calculated authCode did not match the submitted authCode.', 1376899631);


### PR DESCRIPTION
In the new Hook/JumpurlController $GLOBALS['TSFE']->initFEuser(); is called before $GLOBALS['TSFE'] is initiated.

Removed the call as this is done after the hook in RequestHandler/handleRequest
